### PR TITLE
style: add hover opacity transition to navigation links

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -52,7 +52,7 @@ export const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) =>
               <Link
                 key={item.path}
                 to={item.path}
-                className={`flex items-center gap-3 px-4 py-3 rounded-lg transition-all font-medium ${
+                className={`flex items-center gap-3 px-4 py-3 rounded-lg transition-all font-medium hover:opacity-80 ${
                   isActive 
                     ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-400' 
                     : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-200'
@@ -107,7 +107,7 @@ export const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) =>
             <Link
               key={item.path}
               to={item.path}
-              className={`flex flex-col items-center gap-1 text-xs font-medium ${
+              className={`flex flex-col items-center gap-1 text-xs font-medium transition-opacity hover:opacity-80 ${
                 isActive ? 'text-blue-600 dark:text-blue-400' : 'text-gray-500 dark:text-gray-500'
               }`}
             >


### PR DESCRIPTION
Hi @abduznik! I've implemented the hover feedback for the navigation elements as requested in issue #11.

Changes made:

Desktop Sidebar: Added hover:opacity-80 to the navigation links. I noticed transition-all was already present in the class list, so I opted not to add a redundant transition-opacity class to keep the code clean.

Mobile Bottom Nav: Added both transition-opacity and hover:opacity-80 to the mobile navigation links to ensure smooth interaction feedback on smaller screens.

Closes #11