### PR TITLE
fix: update document meta title

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>filament-tracker</title>
+    <title>Filament Tracker</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
This PR updates the <title> tag in index.html to correctly display the project name "Filament Tracker" instead of the default template value.
Improves browser tab context  
 Improves accessibility  
 Improves SEO metadata  
Fixes: #10
