### PR TITLE
Fix: Correct base routing for live demo and bump to v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "filament-tracker",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/filament-tracker/',
 })


### PR DESCRIPTION
Fixes #1. Sets the correct Vite base path for GitHub Pages sub-folder deployment and bumps version to 0.2.0.