### PR TITLE
Implement Mobile Camera Capture

### DIFF
--- a/src/pages/AddFilament.tsx
+++ b/src/pages/AddFilament.tsx
@@ -75,6 +75,7 @@ export const AddFilament: React.FC = () => {
               <input 
                 type="file" 
                 accept="image/*"
+                capture="environment"
                 onChange={handlePhotoChange}
                 className="absolute inset-0 opacity-0 cursor-pointer"
               />


### PR DESCRIPTION
This PR adds the `capture="environment"` attribute to the filament photo input, prioritizing the rear camera on mobile devices. Fixes #24.