### PR TITLE
fix: add cleanup for image preview object URL

### DIFF
--- a/src/pages/AddFilament.tsx
+++ b/src/pages/AddFilament.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { db } from '../db';
 import { Upload, ChevronLeft, Save } from 'lucide-react';
@@ -15,6 +15,15 @@ export const AddFilament: React.FC = () => {
   const [cost, setCost] = useState(20);
   const [photo, setPhoto] = useState<Blob | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
+
+  // Clean up object URL to avoid memory leaks
+  useEffect(() => {
+    return () => {
+      if (preview) {
+        URL.revokeObjectURL(preview);
+      }
+    };
+  }, [preview]);
 
   const handlePhotoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {


### PR DESCRIPTION
This PR adds a useEffect hook to revoke the object URL created for the image preview, preventing potential memory leaks. Closes #25.