### PR TITLE
fix(docker): copy pre-compiled better-sqlite3 from build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ WORKDIR /app
 COPY package*.json ./
 # Install only production dependencies
 RUN npm install --omit=dev
-# Need better-sqlite3 specifically
-RUN npm install better-sqlite3
+# Copy pre-compiled better-sqlite3 from build stage (avoids native build tools in prod)
+COPY --from=build-stage /app/node_modules/better-sqlite3 ./node_modules/better-sqlite3
 
 COPY --from=build-stage /app/dist ./dist
 COPY server.js ./


### PR DESCRIPTION
## Problem

The `Deploy & Release` CI workflow fails at the Docker build step with:

```
gyp ERR! stack at async configure (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:27:18)
gyp ERR! System Linux 6.17.0-1018-azure
gyp ERR! node -v v20.20.2
gyp ERR! node-gyp -v v10.1.0
gyp ERR! not ok
```

`better-sqlite3` is a native C++ addon that compiles via `node-gyp`, but the production stage uses `node:20-alpine` which has no build tools (`g++`, `make`, `python3`).

## Fix

Instead of installing build tools in the production image (which increases attack surface and image size), copy the already-compiled `better-sqlite3` binary from the build stage. The build stage already runs `npm install` which compiles it successfully.

## Changes

`Dockerfile` — 1 file, 2 lines changed:
- Removed `RUN npm install better-sqlite3` (fails in prod stage)
- Added `COPY --from=build-stage .../better-sqlite3 ...` (reuses compiled binary)